### PR TITLE
Fix missing index html file

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
+import { existsSync } from 'node:fs';
 
 // The Express app is exported so that it can be used by serverless Functions.
 export function app(): express.Express {
@@ -10,40 +11,66 @@ export function app(): express.Express {
   // Detectar ambiente: desarrollo vs producción
   const isProduction = process.env['NODE_ENV'] === 'production';
 
-  // En Amplify, el servidor busca en diferentes rutas
+  // Función para verificar si una ruta existe
+  function pathExists(path: string): boolean {
+    try {
+      return existsSync(path);
+    } catch (e) {
+      return false;
+    }
+  }
+
+  // En producción, buscar en diferentes rutas posibles
   let browserDistFolder: string = '';
   if (isProduction) {
     // Intentar diferentes rutas en producción
     const possiblePaths = [
+      // Para AWS Amplify y otros servicios cloud
+      resolve(serverDistFolder, '../browser'), // dist/glow-skin-angular/browser
+      resolve(serverDistFolder, '../../browser'), // browser (si está en raíz)
       resolve(serverDistFolder, '../../static'), // .amplify-hosting/static
-      resolve(serverDistFolder, '../browser'), // /var/browser
-      resolve(serverDistFolder, '../../browser'), // /var/browser (alternativa)
-      '/var/browser', // Ruta directa
-      '/var/static', // Ruta directa
+      resolve(serverDistFolder, '../../../browser'), // dist/browser
+      '/var/browser', // Ruta directa para algunos servicios
+      '/app/dist/glow-skin-angular/browser', // Ruta completa en containers
+      '/workspace/dist/glow-skin-angular/browser', // Ruta de workspace
+      // Rutas adicionales para diferentes entornos
+      process.cwd() + '/dist/glow-skin-angular/browser',
+      process.cwd() + '/browser',
     ];
 
+    console.log('Buscando archivos del browser en las siguientes rutas:');
+    
     // Usar la primera ruta que existe
     for (const path of possiblePaths) {
-      try {
-        require('fs').accessSync(path);
+      console.log(`  Probando: ${path}`);
+      if (pathExists(path) && pathExists(join(path, 'index.html'))) {
         browserDistFolder = path;
+        console.log(`  ✓ Encontrado en: ${path}`);
         break;
-      } catch (e) {
-        // Continuar con la siguiente ruta
+      } else {
+        console.log(`  ✗ No encontrado en: ${path}`);
       }
     }
 
-    // Si no se encontró ninguna, usar la ruta por defecto
+    // Si no se encontró ninguna, usar la ruta por defecto y mostrar error detallado
     if (!browserDistFolder) {
-      browserDistFolder = resolve(serverDistFolder, '../../static');
+      browserDistFolder = resolve(serverDistFolder, '../browser');
+      console.error('❌ No se encontraron archivos del browser en ninguna ruta!');
+      console.error('Usando ruta por defecto:', browserDistFolder);
+      console.error('Directorio actual del servidor:', serverDistFolder);
+      console.error('Directorio de trabajo:', process.cwd());
     }
   } else {
-    browserDistFolder = resolve(serverDistFolder, '../browser'); // Local
+    // Desarrollo local
+    browserDistFolder = resolve(serverDistFolder, '../browser');
   }
 
+  console.log('=== CONFIGURACIÓN DEL SERVIDOR ===');
   console.log('Server Dist Folder:', serverDistFolder);
   console.log('Browser Dist Folder:', browserDistFolder);
   console.log('Is Production:', isProduction);
+  console.log('Index.html existe:', pathExists(join(browserDistFolder, 'index.html')));
+  console.log('===================================');
 
   // Serve static files from /browser
   server.get(
@@ -55,7 +82,21 @@ export function app(): express.Express {
 
   // All regular routes use the Universal engine
   server.get('*', (req, res) => {
-    res.sendFile(join(browserDistFolder, 'index.html'));
+    const indexPath = join(browserDistFolder, 'index.html');
+    
+    if (!pathExists(indexPath)) {
+      console.error(`❌ Error: No se puede encontrar index.html en: ${indexPath}`);
+      res.status(500).send(`
+        <h1>Error del Servidor</h1>
+        <p>No se puede encontrar el archivo index.html</p>
+        <p>Ruta buscada: ${indexPath}</p>
+        <p>Directorio del servidor: ${serverDistFolder}</p>
+        <p>Directorio de trabajo: ${process.cwd()}</p>
+      `);
+      return;
+    }
+    
+    res.sendFile(indexPath);
   });
 
   return server;


### PR DESCRIPTION
Make the Angular SSR server more robust by checking multiple paths for static assets, resolving `ENOENT` errors in various deployment environments.

The server was failing to find `index.html` because it was looking in a fixed path (`/var/browser`) that didn't match the actual deployment location of the compiled Angular application (e.g., `dist/glow-skin-angular/browser` or `/workspace/dist/glow-skin-angular/browser`). This PR enhances the server's logic to probe common deployment paths for the static assets and provides better error handling and logging.

---
<a href="https://cursor.com/background-agent?bcId=bc-01c542a3-a5e2-49bc-9e81-d38512883080">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01c542a3-a5e2-49bc-9e81-d38512883080">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>